### PR TITLE
fix: update Zustand snippet to v4+ syntax

### DIFF
--- a/snippets/javascript.json
+++ b/snippets/javascript.json
@@ -985,7 +985,7 @@
   "🟨 zuCreate": {
     "prefix": "zuc.$zuc",
     "body": [
-      "import create from 'zustand'",
+      "import {create} from 'zustand'",
       "",
       "const use${1:Store} = create((set) => ({",
       "\t${0:// code}",
@@ -999,7 +999,7 @@
   "🟨 zuCreateImmer": {
     "prefix": "zuci.$zuci",
     "body": [
-      "import create from 'zustand'",
+      "import {create} from 'zustand'",
       "import { immer } from 'zustand/middleware/immer'",
       "",
       "const use${1:Store} = create(immer((set) => ({",


### PR DESCRIPTION
Updated Zustand snippet import from default to named export to match Zustand v4+ syntax.